### PR TITLE
Format files + change the command title

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -25,12 +25,12 @@ function activate(context) {
 
         let links = vscode.workspace.getConfiguration('global-config').get('links');
 
-        fs.readdir(source, function (err, list) {
+        fs.readdir(source, (err, list) => {
             if (err) {
                 console.log(err);
             }
             else {
-                list.forEach(function (entry) {
+                list.forEach((entry) => {
                     let file = path.join(source, entry);
 
                     let stat = fs.statSync(file);
@@ -55,7 +55,4 @@ function activate(context) {
     context.subscriptions.push(disposable);
 }
 exports.activate = activate;
-
-function deactivate() {
-}
-exports.deactivate = deactivate;
+exports.deactivate = () => { };

--- a/extension.js
+++ b/extension.js
@@ -1,75 +1,61 @@
 
-var vscode = require( 'vscode' ),
-    fs = require( 'fs-extra' ),
-    os = require( 'os' ),
-    path = require( 'path' );
+let vscode = require('vscode'),
+    fs = require('fs-extra'),
+    os = require('os'),
+    path = require('path');
 
-function activate( context )
-{
-    function copyConfig()
-    {
-        var source = vscode.workspace.getConfiguration( 'global-config' ).get( 'folder' );
+function activate(context) {
+    function copyConfig() {
+        let source = vscode.workspace.getConfiguration('global-config').get('folder');
 
-        if( source.startsWith( "~" ) )
-        {
-            source = path.join( os.homedir(), source.substr( 1 ) );
+        if (source.startsWith("~")) {
+            source = path.join(os.homedir(), source.substr(1));
         }
 
-        var workspacePath;
-        if( vscode.workspaceFolders && vscode.workspaceFolders.length > 0 )
-        {
-            workspacePath = vscode.workspace.workspaceFolders[ 0 ];
+        let workspacePath;
+        if (vscode.workspaceFolders && vscode.workspaceFolders.length > 0) {
+            workspacePath = vscode.workspace.workspaceFolders[0];
         }
-        if( workspacePath === undefined )
-        {
+        if (workspacePath === undefined) {
             workspacePath = vscode.workspace.rootPath;
         }
 
-        var destination = path.join( workspacePath, ".vscode" );
-        fs.ensureDirSync( destination );
+        let destination = path.join(workspacePath, ".vscode");
+        fs.ensureDirSync(destination);
 
-        var links = vscode.workspace.getConfiguration( 'global-config' ).get( 'links' );
+        let links = vscode.workspace.getConfiguration('global-config').get('links');
 
-        fs.readdir( source, function( err, list )
-        {
-            if( err )
-            {
-                console.log( err );
+        fs.readdir(source, function (err, list) {
+            if (err) {
+                console.log(err);
             }
-            else
-            {
-                list.forEach( function( entry )
-                {
-                    var file = path.join( source, entry );
+            else {
+                list.forEach(function (entry) {
+                    let file = path.join(source, entry);
 
-                    var stat = fs.statSync( file );
-                    if( stat && !stat.isDirectory() )
-                    {
-                        var target = path.join( destination, entry );
-                        if( links.indexOf( entry ) > -1 )
-                        {
-                            if( !fs.existsSync( target ) )
-                            {
-                                fs.symlinkSync( file, target );
+                    let stat = fs.statSync(file);
+                    if (stat && !stat.isDirectory()) {
+                        let target = path.join(destination, entry);
+                        if (links.indexOf(entry) > -1) {
+                            if (!fs.existsSync(target)) {
+                                fs.symlinkSync(file, target);
                             }
                         }
-                        else
-                        {
-                            fs.copySync( file, target, { overwrite: false } );
+                        else {
+                            fs.copySync(file, target, { overwrite: false });
                         }
                     }
-                } );
+                });
             }
-        } );
+        });
     }
 
-    var disposable = vscode.commands.registerCommand( 'global-config.copy', copyConfig );
+    let disposable = vscode.commands.registerCommand('global-config.copy', copyConfig);
 
-    context.subscriptions.push( disposable );
+    context.subscriptions.push(disposable);
 }
 exports.activate = activate;
 
-function deactivate()
-{
+function deactivate() {
 }
 exports.deactivate = deactivate;

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"commands": [
 			{
 				"command": "global-config.copy",
-				"title": "Copy global config"
+				"title": "Copy Global Config"
 			}
 		],
 		"configuration": {


### PR DESCRIPTION
Hey!

I was kinda bothered by the fact that the command title was `Copy global config`, rather than what all other extensions / settings use - 

![](https://i.imgur.com/s6lV6ik.png)

So I went ahead and just changed it to `Copy Global Config`. I also formatted the extension.js file, replaced var with let and made some of the functions anonymous, (ES6 standards).
