### PR TITLE
added setting allowing duplicate files

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -1,129 +1,114 @@
 
-let vscode = require( 'vscode' ),
-    fs = require( 'fs-extra' ),
-    os = require( 'os' ),
-    path = require( 'path' );
+let vscode = require('vscode'),
+fs = require('fs-extra'),
+os = require('os'),
+path = require('path');
 
-function activate( context )
-{
-    var outputChannel;
+function activate(context) {
+var outputChannel;
 
-    function debug( text )
-    {
-        if( outputChannel === undefined )
-        {
-            outputChannel = vscode.window.createOutputChannel( "Global Config" );
-        }
+function debug(text) {
+	if (outputChannel === undefined) {
+		outputChannel = vscode.window.createOutputChannel("Global Config");
+	}
 
-        outputChannel.appendLine( text );
-    }
+	outputChannel.appendLine(text);
+}
 
-    function copyConfig()
-    {
-        function copyToWorkspace( workspacePath, source )
-        {
-            debug( " Updating " + workspacePath + " from " + source );
+function copyConfig() {
+	function copyToWorkspace(workspacePath, source) {
+		debug(" Updating " + workspacePath + " from " + source);
 
-            let destination = path.join( workspacePath, ".vscode" );
-            fs.ensureDirSync( destination );
+		let destination = path.join(workspacePath, ".vscode");
+		fs.ensureDirSync(destination);
 
-            let links = vscode.workspace.getConfiguration( 'global-config' ).get( 'links' );
+		let links = vscode.workspace.getConfiguration('global-config').get('links');
+		let duplicate = vscode.workspace.getConfiguration('global-config').get('duplicate');
 
-            fs.readdir( source, ( err, list ) =>
-            {
-                if( err )
-                {
-                    debug( err );
-                }
-                else
-                {
-                    list.forEach( ( entry ) =>
-                    {
-                        let file = path.join( source, entry );
+		fs.readdir(source, (err, list) => {
+			if (err) {
+				debug(err);
+			}
+			else {
+				list.forEach((entry) => {
+					let file = path.join(source, entry);
 
-                        let stat = fs.statSync( file );
-                        if( stat )
-                        {
-                            let target = path.join( destination, entry );
-                            if( fs.existsSync( target ) )
-                            {
-                                debug( "  Ignoring existing " + target );
-                            }
-                            else
-                            {
-                                if( links.indexOf( entry ) > -1 )
-                                {
-                                    debug( "  Linking " + entry + " -> " + destination );
-                                    fs.symlinkSync( file, target );
-                                }
-                                else
-                                {
-                                    debug( "  Copying " + entry + " -> " + destination );
-                                    fs.copySync( file, target, { overwrite: false } );
-                                }
-                            }
-                        }
-                    } );
-                }
-            } );
-        }
+					let stat = fs.statSync(file);
+					if (stat) {
+						let target = path.join(destination, entry);
+						if (fs.existsSync(target)) {
+							if (duplicate) {
+								let newFile = path.parse(entry).name + "-copy.json";
+								let dtarget = path.join(destination, newFile);
+								debug("  Renaming " + entry + " -> " + newFile);
+								debug("  Copying " + newFile + " -> " + destination);
+								vscode.window.showInformationMessage("Files duplicated, remove \"-copy\" for configs to take effect");
+								fs.copySync(file, dtarget, { overwrite: false });
+							} else {
+								debug("  Ignoring existing " + target);
+							}
+						}
+						else {
+							if (links.indexOf(entry) > -1) {
+								debug("  Linking " + entry + " -> " + destination);
+								fs.symlinkSync(file, target);
+							}
+							else {
+								debug("  Copying " + entry + " -> " + destination);
+								fs.copySync(file, target, { overwrite: false });
+							}
+						}
+					}
+				});
+			}
+		});
+	}
 
-        function updateWorkspaces( source )
-        {
-            if( source )
-            {
-                if( vscode.workspace.workspaceFolders )
-                {
-                    debug( "Updating workspaces..." );
-                    vscode.workspace.workspaceFolders.map( function( workspaceFolder )
-                    {
-                        copyToWorkspace( workspaceFolder.uri.fsPath, source );
-                    } );
-                }
-            }
-        }
+	function updateWorkspaces(source) {
+		if (source) {
+			if (vscode.workspace.workspaceFolders) {
+				debug("Updating workspaces...");
+				vscode.workspace.workspaceFolders.map(function (workspaceFolder) {
+					copyToWorkspace(workspaceFolder.uri.fsPath, source);
+				});
+			}
+		}
+	}
 
-        let source = vscode.workspace.getConfiguration( 'global-config' ).get( 'folder' );
+	let source = vscode.workspace.getConfiguration('global-config').get('folder');
 
-        if( source.startsWith( "~" ) )
-        {
-            source = path.join( os.homedir(), source.substr( 1 ) );
-        }
+	if (source.startsWith("~")) {
+		source = path.join(os.homedir(), source.substr(1));
+	}
 
-        var folders = fs.readdirSync( source ).filter( function( entry )
-        {
-            return fs.statSync( path.join( source, entry ) ).isDirectory();
-        } );
+	var folders = fs.readdirSync(source).filter(function (entry) {
+		return fs.statSync(path.join(source, entry)).isDirectory();
+	});
 
-        if( folders.length > 0 )
-        {
-            debug( "Found subfolders in " + source + "..." );
-            vscode.window.showQuickPick( folders, { placeholder: "Please select a folder" } ).then( function( selected )
-            {
-                if( selected )
-                {
-                    source = path.join( source, selected );
-                    debug( " Selected subfolder: " + source );
-                    updateWorkspaces( source );
-                }
-                else
-                {
-                    source = undefined;
-                    debug( " Cancelled" );
-                }
-            } );
-        }
-        else
-        {
-            updateWorkspaces( source );
-        }
-    }
+	if (folders.length > 0) {
+		debug("Found subfolders in " + source + "...");
+		vscode.window.showQuickPick(folders, { placeholder: "Please select a folder" }).then(function (selected) {
+			if (selected) {
+				source = path.join(source, selected);
+				debug(" Selected subfolder: " + source);
+				updateWorkspaces(source);
+			}
+			else {
+				source = undefined;
+				debug(" Cancelled");
+			}
+		});
+	}
+	else {
+		updateWorkspaces(source);
+	}
+}
 
-    let disposable = vscode.commands.registerCommand( 'global-config.copy', copyConfig );
+let disposable = vscode.commands.registerCommand('global-config.copy', copyConfig);
 
-    debug( "Ready" );
+debug("Ready");
 
-    context.subscriptions.push( disposable );
+context.subscriptions.push(disposable);
 }
 exports.activate = activate;
 exports.deactivate = () => { };

--- a/package.json
+++ b/package.json
@@ -1,63 +1,68 @@
 {
-    "name": "global-config",
-    "displayName": "Global Config",
-    "description": "Copies global config files (settings.json, tasks.json, etc.) to workspace config folder",
-    "keywords": [
-        "config",
-        "multi-root ready"
-    ],
-    "icon": "icon.png",
-    "version": "0.0.12",
-    "publisher": "Gruntfuggly",
-    "repository": "https://github.com/Gruntfuggly/global-config",
-    "engines": {
-        "vscode": "^1.5.0"
-    },
-    "categories": [
-        "Other"
-    ],
-    "activationEvents": [
-        "*"
-    ],
-    "main": "./extension",
-    "contributes": {
-        "commands": [
-            {
-                "command": "global-config.copy",
-                "title": "Copy Global Config"
-            }
-        ],
-        "configuration": {
-            "type": "object",
-            "title": "Global Config",
-            "properties": {
-                "global-config.folder": {
-                    "type": "string",
-                    "description": "The folder containing your default config files",
-                    "default": "~/.vscode/"
-                },
-                "global-config.links": {
-                    "type": "array",
-                    "description": "A list of files that should be soft linked rather than copied",
-                    "default": []
-                }
-            }
-        }
-    },
-    "devDependencies": {
-        "typescript": "^2.0.3",
-        "vscode": "^1.0.0",
-        "mocha": "^2.3.3",
-        "eslint": ">=4.18.2",
-        "@types/node": "^6.0.40",
-        "@types/mocha": "^2.2.32"
-    },
-    "dependencies": {
-        "fs-extra": "^5.0.0"
-    },
-    "__metadata": {
-        "id": "9a3d81ec-d459-4139-aa0f-d07452e0e894",
-        "publisherDisplayName": "Gruntfuggly",
-        "publisherId": "d4906d2e-f2ee-492d-9c7c-02b6160599ec"
-    }
+	"name": "global-config",
+	"displayName": "Global Config",
+	"description": "Copies global config files (settings.json, tasks.json, etc.) to workspace config folder",
+	"keywords": [
+		"config",
+		"multi-root ready"
+	],
+	"icon": "icon.png",
+	"version": "0.0.12",
+	"publisher": "Gruntfuggly",
+	"repository": "https://github.com/Gruntfuggly/global-config",
+	"engines": {
+		"vscode": "^1.5.0"
+	},
+	"categories": [
+		"Other"
+	],
+	"activationEvents": [
+		"*"
+	],
+	"main": "./extension",
+	"contributes": {
+		"commands": [
+			{
+				"command": "global-config.copy",
+				"title": "Copy Global Config"
+			}
+		],
+		"configuration": {
+			"type": "object",
+			"title": "Global Config",
+			"properties": {
+				"global-config.folder": {
+					"type": "string",
+					"description": "The folder containing your default config files",
+					"default": "~/.vscode/"
+				},
+				"global-config.links": {
+					"type": "array",
+					"description": "A list of files that should be soft linked rather than copied",
+					"default": []
+				},
+				"global-config.duplicate": {
+					"type": "boolean",
+					"description": "Controls whether duplicate files will be copied, if so \"-copy\" will be appended",
+					"default": false
+				}
+			}
+		}
+	},
+	"devDependencies": {
+		"typescript": "^2.0.3",
+		"vscode": "^1.0.0",
+		"mocha": "^2.3.3",
+		"eslint": ">=4.18.2",
+		"@types/node": "^6.0.40",
+		"@types/mocha": "^2.2.32"
+	},
+	"dependencies": {
+		"fs-extra": "^5.0.0"
+	},
+	"__metadata": {
+		"id": "9a3d81ec-d459-4139-aa0f-d07452e0e894",
+		"publisherId": "d4906d2e-f2ee-492d-9c7c-02b6160599ec",
+		"publisherDisplayName": "Gruntfuggly"
+	}
 }


### PR DESCRIPTION
tick box setting called duplicate added to settings

if setting is enabled duplicate fliles are copied and  -copy added to the name
      i.e. "tasks-copy.json"

Information Message displayed warning that duplicates were copied and wont take effect until "-copy" is removed

usecase is that if you have workspace specific config files and you want to add your global ones aswell, you can duplicate the global ones and copy/paste the nesessary configs